### PR TITLE
Correct critical porting error and port two corrections from C code.

### DIFF
--- a/nanosvg.js
+++ b/nanosvg.js
@@ -2142,7 +2142,11 @@ function nsvg__parseUrl(/* const char */ str) {
   t[5] = cy;
   ndivs = ((fabsf(da) / (3.14159265358979323846264338327 * 0.5)) + 1.0);
   hda = (da / (ndivs)) / 2.0;
-  kappa = fabsf(((4.0 / 3.0) * (1.0 - cosf(hda))) / sinf(hda));
+  if ((hda < 1e-3) && (hda > -1e-3))
+		hda *= 0.5;
+	else
+		hda = (1.0 - cosf(hda)) / sinf(hda);
+  kappa = fabsf(4.0 / 3.0 * hda);
   if (da < 0.0)
     kappa = -kappa;
 

--- a/nanosvg.js
+++ b/nanosvg.js
@@ -2140,7 +2140,7 @@ function nsvg__parseUrl(/* const char */ str) {
   t[3] = cosrx;
   t[4] = cx;
   t[5] = cy;
-  ndivs = ((fabsf(da) / (3.14159265358979323846264338327 * 0.5)) + 1.0);
+  ndivs = Math.floor((fabsf(da) / (3.14159265358979323846264338327 * 0.5)) + 1.0);
   hda = (da / (ndivs)) / 2.0;
   if ((hda < 1e-3) && (hda > -1e-3))
 		hda *= 0.5;

--- a/nanosvg.js
+++ b/nanosvg.js
@@ -2128,11 +2128,10 @@ function nsvg__parseUrl(/* const char */ str) {
   vy = ((-y1p) - cyp) / ry;
   a1 = nsvg__vecang(1.0, 0.0, ux, uy);
   da = nsvg__vecang(ux, uy, vx, vy);
-  if (fa) {
-    if (da > 0.0)
-      da = da - (2 * 3.14159265358979323846264338327);
-    else
-      da = (2 * 3.14159265358979323846264338327) + da;
+  if (fs == 0 && da > 0) {
+      da -= (2 * 3.14159265358979323846264338327);
+  } else if (fs == 1 && da < 0) {
+      da += (2 * 3.14159265358979323846264338327);
   }
 
   t[0] = cosrx;


### PR DESCRIPTION
The line:
```C
ndivs = (int)(fabsf(da) / (NSVG_PI*0.5f) + 1.0f);
```
Specifically includes the casting of ndivs to `int` type. This is not a throwaway form change since ndivs is the number-of-divisions and needs to be a discrete value. The casting of `float` to `int` in C is a floor function.

In the SVGToGcode (https://github.com/evomotors/SvgToGCode) project:

![Arc error](https://user-images.githubusercontent.com/3302478/133230366-16c78470-3735-4d43-ac46-5d3ab0c38504.png)

--- vs. ---

![Arc correct](https://user-images.githubusercontent.com/3302478/133230430-b3d4f5b0-d21e-45bc-944a-ea6cef84f0ca.png)

Using file: https://gist.github.com/tatarize/8d6b4a8d4fe38acd72d43215e671dcad
